### PR TITLE
Fixes mullvad for papirus theme

### DIFF
--- a/data/database/mullvad.json
+++ b/data/database/mullvad.json
@@ -10,15 +10,15 @@
     "icons": {
         "error": {
             "original": "rdot.png",
-            "theme": "mullvad-error"
+            "theme": "mullvadr"
         },
         "config": {
             "original": "ydot.png",
-            "theme": "mullvad-config"
+            "theme": "mullvady"
         },
         "success": {
             "original": "gdot.png",
-            "theme": "mullvad-success"
+            "theme": "mullvadg"
         }
     }
 }


### PR DESCRIPTION
These are the icon names used for the mullvad tray icons in the papirus theme.