### PR TITLE
RuTracker Proxy support

### DIFF
--- a/data/database/rto-proxy.electron.json
+++ b/data/database/rto-proxy.electron.json
@@ -1,0 +1,17 @@
+{
+    "name": "RuTracker Proxy",
+    "app_path": [
+        "/opt/rto-proxy/"
+    ],
+    "icons_path": [
+        "/opt/rto-proxy/resources/"
+    ],
+    "binary": "app.asar",
+    "script": "electron",
+    "icons": {
+        "tray": {
+            "original": "icons/icon.png",
+            "theme": "rto-proxy-tray"
+        }
+    }
+}


### PR DESCRIPTION
Electron application for unblock IP's trackers on bigger Russian torrent tracker Rutracker.org
Github page: https://github.com/RutrackerOrg/rutracker-proxy