### PR TITLE
QJoyPad support & Vivaldi 1.15

### DIFF
--- a/data/database/qjoypad.json
+++ b/data/database/qjoypad.json
@@ -1,0 +1,15 @@
+{
+    "name": "QJoyPad",
+    "app_path": [
+        "/usr/share/qjoypad/"
+    ],
+    "icons_path": [
+        "/usr/share/icons/hicolor/24x24/apps/"
+    ],
+    "icons": {
+        "tray": {
+            "original": "qjoypad.png",
+            "theme": "qjoypad-tray"
+        }
+    }
+}

--- a/data/database/vivaldi.json
+++ b/data/database/vivaldi.json
@@ -16,6 +16,10 @@
         "tray": {
             "original": "8038",
             "theme": "vivaldi-tray"
+        },
+	"tray1.15": {
+	    "original": "10190",
+	    "theme": "vivaldi-tray"
         }
     }
 }


### PR DESCRIPTION
Qt5 application, but use tray icon from hicolor icon theme and app icon from system icon theme.
https://github.com/panzi/qjoypad/blob/6e7bfa8a063a798efd4ea0eaa750885be892e224/src/layout.cpp#L39
https://github.com/panzi/qjoypad/blob/6e7bfa8a063a798efd4ea0eaa750885be892e224/src/config.h.in#L12
More info here:
https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/issues/1458