### PR TITLE
Fix issue related to `NamedTemporaryFile` in `svg` module (fixes #639)

### DIFF
--- a/HardcodeTray/modules/svg/svg.py
+++ b/HardcodeTray/modules/svg/svg.py
@@ -86,13 +86,9 @@ class SVG:
 
     def to_bin(self, input_file, width=None, height=None):
         """Convert svg to binary."""
-        outfile = NamedTemporaryFile().name
-        self.to_png(input_file, outfile, width, height)
-
-        with open(outfile, 'rb') as temppng:
+        with NamedTemporaryFile() as temppng:
+            self.to_png(input_file, temppng.name, width, height)
             binary = temppng.read()
-        remove(outfile)
-
         return binary
 
     @abstractmethod


### PR DESCRIPTION
See #639.

Using a context makes sure that the `NamedTemporaryFile` used in `to_bin` is only closed when we are done reading its content, and prevents an early deletion of the file if it gets garbage-collected before the results of `to_png` are read.