### PR TITLE
add uppercase Q as a quit option

### DIFF
--- a/HardcodeTray/modules/backup.py
+++ b/HardcodeTray/modules/backup.py
@@ -162,7 +162,7 @@ class Backup:
             while not has_chosen and not stopped:
                 try:
                     selected = input("Select a restore date : ")
-                    if selected in ["q", "quit", "exit"]:
+                    if selected in ["Q", "q", "quit", "exit"]:
                         stopped = True
                     selected = int(selected)
                     if 1 <= selected <= total:


### PR DESCRIPTION
This fixes a bug where on `hardcode-tray -r` the message indicates an uppercase Q is the quit command but it doesn't work

```
(Q)uit to cancel
Select a restore date : Q
Select a restore date : 
```

