### PR TITLE
Improved user privilege handling

### DIFF
--- a/HardcodeTray/app.py
+++ b/HardcodeTray/app.py
@@ -22,9 +22,9 @@ from gettext import gettext as _
 from glob import glob
 from os import path
 
-from HardcodeTray.const import DB_FOLDER
+from HardcodeTray.const import BACKUP_FOLDER, DB_FOLDER
 from HardcodeTray.enum import Action
-from HardcodeTray.utils import progress
+from HardcodeTray.utils import progress, set_user_permissions
 
 from HardcodeTray.modules.log import Logger
 from HardcodeTray.modules.parser import Parser
@@ -130,6 +130,7 @@ class App:
 
         if apps:
             print(_("Took {:.2f}s to finish the tasks").format(total_time))
+            set_user_permissions(BACKUP_FOLDER)
         elif action == Action.APPLY:
             print(_("No apps to fix!"))
         elif action == Action.CLEAR_CACHE:

--- a/HardcodeTray/utils.py
+++ b/HardcodeTray/utils.py
@@ -28,7 +28,7 @@ from sys import stdout
 
 from gi.repository import Gio
 
-from HardcodeTray.const import KDE_CONFIG_FILE
+from HardcodeTray.const import KDE_CONFIG_FILE, USERNAME
 from HardcodeTray.modules.log import Logger
 
 
@@ -295,3 +295,7 @@ def get_exact_folder(key, directory, condition):
         directory = directory.replace(key, exact_directory)
 
     return directory
+
+def set_user_permissions(target):
+    """Set permissions to user instead of root."""
+    execute(["chown", "-R", "%s:%s" % (USERNAME, USERNAME), target])

--- a/hardcode-tray.py.in
+++ b/hardcode-tray.py.in
@@ -41,9 +41,10 @@ from HardcodeTray.app import App
 from HardcodeTray.const import DESKTOP_ENV, ICONS_SIZE, THEMES_LIST
 from HardcodeTray.enum import Action, ConversionTools
 
-if geteuid() != 0:
-    print(_("You need to have root privileges to run the script."))
-    exit(_("Please try again, this time using 'sudo'. Exiting."))
+def check_root():
+    if geteuid() != 0:
+        print(_("\nYou need to have root privileges to modify system files."))
+        exit(_("Please try again, this time using 'sudo'. Exiting."))
 
 parser = ArgumentParser(prog="@PACKAGE@")
 parser.add_argument("--apply", "-a", action='store_true',
@@ -112,8 +113,10 @@ else:
 
     action = App.get("action")
     if action == Action.APPLY:
+        check_root()
         print(_("Applying now.."))
     elif action == Action.REVERT:
+        check_root()
         print(_("Reverting now.."))
     elif action == Action.CLEAR_CACHE:
         print(_("Clearing cache..."))


### PR DESCRIPTION
This fix allows executing Hardcode-Tray by a regular user for actions, that don't require root privileges (getting version or clearing cache).

Just a reminder. Old cache owned by root should be removed before testing.
`sudo rm -rf ~/.config/Hardcode-Tray`

Closes https://github.com/bilelmoussaoui/Hardcode-Tray/issues/397 and https://github.com/bilelmoussaoui/Hardcode-Tray/issues/645.