### PR TITLE
update Discord version to 0.0.14

### DIFF
--- a/data/database/discord.electron.json
+++ b/data/database/discord.electron.json
@@ -4,7 +4,7 @@
         "{userhome}/.config/discord"
     ],
     "icons_path": [
-        "{userhome}/.config/discord/0.0.13/modules/discord_desktop_core/"
+        "{userhome}/.config/discord/0.0.14/modules/discord_desktop_core/"
     ],
     "binary": "core.asar",
     "script": "electron",


### PR DESCRIPTION
This morning I got a Discord update (a new `.deb` package) so my custom tray icon was gone. Tried to fix it as usual but Hardcode-Tray reported "no apps to fix". Changing the version number in `data/database/discord.electron.json` fixed the issue and Hardcode-Tray correctly replaced my tray icon.