### PR TITLE
updated Discord to version 0.0.15

### DIFF
--- a/data/database/discord.electron.json
+++ b/data/database/discord.electron.json
@@ -4,7 +4,7 @@
         "{userhome}/.config/discord"
     ],
     "icons_path": [
-        "{userhome}/.config/discord/0.0.14/modules/discord_desktop_core/"
+        "{userhome}/.config/discord/0.0.15/modules/discord_desktop_core/"
     ],
     "binary": "core.asar",
     "script": "electron",


### PR DESCRIPTION
Another Discord update broke the tray icon today. Updating `/data/database/discord.electron.json` as before, and rebuilding/reinstalling, I replaced the tray icon successfully with my own custom icon once again.
![discordtray](https://user-images.githubusercontent.com/4255997/119441853-8062c000-bd2f-11eb-80cc-3a242b84d5c6.png)
