### PR TITLE
Fix crash when calculating Asar file content offsets

### DIFF
--- a/HardcodeTray/utils.py
+++ b/HardcodeTray/utils.py
@@ -242,8 +242,11 @@ def change_dict_vals(d, sizediff, offset):
     """Iterative funtion to account for the new size of the png bytearray."""
     if isinstance(d, dict):
         d2 = {k: change_dict_vals(v, sizediff, offset) for k, v in d.items()}
-        if d2.get('offset') and int(d2.get('offset')) > offset:
-            d2['offset'] = str(int(d2['offset']) + sizediff)
+        ofval = d2.get('offset')
+        if ofval and isinstance(ofval, str):
+            ofval = int(ofval)
+            if ofval > offset:
+                d2['offset'] = str(ofval + sizediff)
         return d2
     return d
 


### PR DESCRIPTION
Fixes #704, #637, #646

Some Electron apps such as Mattermost Desktop 5.0.0 contain a directory named "offset" in their app.asar files, which is treated in code as a `dict` of `dict`s representing files and subdirectories. Hardcode Tray expects a string for actual offset values before recalculating them. This fix adds a check to make sure that it only performs the said action on offset numbers.

~~However, another bug came up as I completed this. For some reason, Hardcode Tray could no longer find unread and mentioned tray icons for Mattermost Desktop 5.0.0, leaving them intact as a result. This PR is complete once I have a fix for that side effect pushed into this PR and no further side effects appear.~~

**Edit:** The side effect was rather caused by typos in the proposed changes to `mattermost.electron.json`. Details are found in [my comment on the mentioned issue](https://github.com/bilelmoussaoui/Hardcode-Tray/issues/704#issuecomment-925466020).