### PR TITLE
Added Discord callback

### DIFF
--- a/HardcodeTray/modules/path.py
+++ b/HardcodeTray/modules/path.py
@@ -37,6 +37,7 @@ class Path:
         "{userhome}": USERHOME,
         "{size}": 22,
         "{arch}": ARCH,
+        "{discord}": "discord_callback",
         "{dropbox}": "dropbox_callback",
         "{hangouts}": "hangouts_callback"
     }

--- a/HardcodeTray/path.py
+++ b/HardcodeTray/path.py
@@ -22,6 +22,18 @@ along with Hardcode-Tray. If not, see <http://www.gnu.org/licenses/>.
 from os import path
 
 
+def discord_callback(directory):
+    """
+    Correct the hardcoded discord directory.
+
+    Args:
+        directory(str): the default discord config directory
+    """
+    if path.isdir(directory):
+        return path.isdir(path.join(directory, 'modules/discord_desktop_core'))
+    return False
+
+
 def dropbox_callback(directory):
     """
     Correct the hardcoded dropbox directory.

--- a/data/database/discord.electron.json
+++ b/data/database/discord.electron.json
@@ -5,8 +5,8 @@
         "{userhome}/.var/app/com.discordapp.Discord"
     ],
     "icons_path": [
-        "{userhome}/.config/discord/0.0.16/modules/discord_desktop_core/",
-        "{userhome}/.var/app/com.discordapp.Discord/config/discord/0.0.16/modules/discord_desktop_core/"
+        "{userhome}/.config/discord/{discord}/modules/discord_desktop_core/",
+        "{userhome}/.var/app/com.discordapp.Discord/config/discord/{discord}/modules/discord_desktop_core/"
     ],
     "binary": "core.asar",
     "script": "electron",


### PR DESCRIPTION
This PR adds a callback for Discord. Simply put it adds `{discord}` variable instead of the version number in the path like `{userhome}/.config/discord/{discord}/modules/discord_desktop_core/`.

It will be useful for fixing #685

Not tested yet.