### PR TITLE
Add mising caprine.electron paths

### DIFF
--- a/data/database/caprine.electron.json
+++ b/data/database/caprine.electron.json
@@ -2,11 +2,13 @@
     "name": "Caprine",
     "app_path": [
         "/usr/share/caprine/",
+        "/usr/lib64/caprine/",
         "/opt/Caprine/",
         "/var/lib/flatpak/app/com.sindresorhus.Caprine"
     ],
     "icons_path": [
         "/usr/share/caprine/resources/",
+        "/usr/lib64/caprine/resources/",
         "/opt/Caprine/resources/",
         "/var/lib/flatpak/app/com.sindresorhus.Caprine/current/active/files/main/resources/"
     ],


### PR DESCRIPTION
This adds the paths used by the RPM package provided in the [dusansimic/caprine COPR](https://copr.fedorainfracloud.org/coprs/dusansimic/caprine/).